### PR TITLE
fix: placement of task type in values(MAPCO-4463)

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -33,7 +33,7 @@ data:
   INGESTION_NEW_JOB_TYPE: {{ $jobManagement.ingestion.new.jobType | quote }}
   INGESTION_UPDATE_JOB_TYPE: {{ $jobManagement.ingestion.update.jobType | quote }}
   INGESTION_SWAP_UPDATE_JOB_TYPE: {{ $jobManagement.ingestion.updateSwap.jobType | quote }}
-  INIT_TASK_TYPE: {{ $jobManagement.tasks.initTaskType | quote }}
+  INIT_TASK_TYPE: {{ $jobManagement.ingestion.init.taskType | quote }}
   CRS: {{ .Values.env.validationValuesByInfo.crs | toJson | quote}}
   FILE_FORMAT: {{ .Values.env.validationValuesByInfo.fileFormat | toJson | quote}}
   TILE_SIZE: {{ .Values.env.validationValuesByInfo.tileSize | quote}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -9,9 +9,9 @@ global:
     jobManager: ""
   jobManagement:
     jobDomain: RASTER
-    tasks:
-      initTaskType: ""
     ingestion:
+      init:
+        taskType: ""
       new: 
         jobType: ""
       update: 
@@ -47,9 +47,9 @@ serviceUrls:
   jobManager: ""
 jobManagement:
   jobDomain: ""
-  tasks:
-      initTaskType: ""
   ingestion:
+    init:
+      taskType: ""
     new: 
       jobType: ""
     update: 


### PR DESCRIPTION
move the task type key in the helm-chart value to 'ingestion' scope under 'init' scope

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


