### PR TITLE
fix: return 404 on layer not in catalog on update (MAPCO-4959)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -100,6 +100,13 @@ paths:
               schema:
                 $ref: >-
                   ./Schema/ingestionTrigger/responses/ingestionTriggerResponses.yaml#/components/schemas/errorMessage
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: >-
+                  ./Schema/ingestionTrigger/responses/ingestionTriggerResponses.yaml#/components/schemas/errorMessage
         '409':
           description: Conflict
           content:

--- a/src/ingestion/models/ingestionManager.ts
+++ b/src/ingestion/models/ingestionManager.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
 import { InputFiles, ProductType, NewRasterLayer, UpdateRasterLayer, PolygonPart } from '@map-colonies/mc-model-types';
-import { ConflictError, BadRequestError, NotFoundError } from '@map-colonies/error-types';
+import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { ICreateJobResponse, IJobResponse, OperationStatus, IFindJobsByCriteriaBody } from '@map-colonies/mc-priority-queue';
 import { SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 import { withSpanAsyncV4 } from '@map-colonies/telemetry';
@@ -303,7 +303,7 @@ export class IngestionManager {
         msg: message,
         logCtx: logCtx,
       });
-      const error = new BadRequestError(message);
+      const error = new NotFoundError(message);
       trace.getActiveSpan()?.setAttribute('exception.type', error.status);
       throw error;
     }

--- a/src/ingestion/models/ingestionManager.ts
+++ b/src/ingestion/models/ingestionManager.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
 import { InputFiles, ProductType, NewRasterLayer, UpdateRasterLayer, PolygonPart } from '@map-colonies/mc-model-types';
-import { ConflictError, BadRequestError } from '@map-colonies/error-types';
+import { ConflictError, BadRequestError, NotFoundError } from '@map-colonies/error-types';
 import { ICreateJobResponse, IJobResponse, OperationStatus, IFindJobsByCriteriaBody } from '@map-colonies/mc-priority-queue';
 import { SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 import { withSpanAsyncV4 } from '@map-colonies/telemetry';
@@ -333,7 +333,7 @@ export class IngestionManager {
     const getLayerSpan = trace.getActiveSpan();
     if (layerDetails.length === 0) {
       const message = `there isnt a layer with id of ${catalogId}`;
-      const error = new BadRequestError(message);
+      const error = new NotFoundError(message);
       getLayerSpan?.setAttribute('exception.type', error.status);
       throw error;
     } else if (layerDetails.length !== 1) {

--- a/tests/integration/ingestion/ingestion.spec.ts
+++ b/tests/integration/ingestion/ingestion.spec.ts
@@ -661,7 +661,7 @@ describe('Ingestion', function () {
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
       });
 
-      it('should return 400 status code when the layer is not in mapProxy', async () => {
+      it('should return 404 status code when the layer is not in mapProxy', async () => {
         const layerRequest = updateLayerRequest.valid;
         const updatedLayerMetadata = updatedLayer.metadata;
         const updateLayerName = getMapServingLayerName(updatedLayerMetadata.productId, updatedLayerMetadata.productType as ProductType);
@@ -674,7 +674,7 @@ describe('Ingestion', function () {
         const response = await requestSender.updateLayer(updatedLayerMetadata.id, layerRequest);
 
         expect(response).toSatisfyApiSpec();
-        expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+        expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
       });
 
       it('should return 409 status code when there are conflicting jobs', async () => {

--- a/tests/integration/ingestion/ingestion.spec.ts
+++ b/tests/integration/ingestion/ingestion.spec.ts
@@ -639,7 +639,7 @@ describe('Ingestion', function () {
         expect(response.status).toBe(httpStatusCodes.CONFLICT);
       });
 
-      it('should return 400 status code when there is no such layer in the catalog', async () => {
+      it('should return 404 status code when there is no such layer in the catalog', async () => {
         const layerRequest = updateLayerRequest.valid;
         const updatedLayerMetadata = updatedLayer.metadata;
 
@@ -648,7 +648,7 @@ describe('Ingestion', function () {
         const response = await requestSender.updateLayer(updatedLayerMetadata.id, layerRequest);
 
         expect(response).toSatisfyApiSpec();
-        expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+        expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
       });
 
       it('should return 400 status code when there is a validation error', async () => {

--- a/tests/unit/ingestion/models/ingestionManager.spec.ts
+++ b/tests/unit/ingestion/models/ingestionManager.spec.ts
@@ -1,6 +1,6 @@
 import jsLogger from '@map-colonies/js-logger';
 import nock from 'nock';
-import { ConflictError, BadRequestError, NotFoundError } from '@map-colonies/error-types';
+import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { ProductType } from '@map-colonies/mc-model-types';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import { trace } from '@opentelemetry/api';
@@ -287,7 +287,7 @@ describe('IngestionManager', () => {
       await expect(action()).rejects.toThrow(ConflictError);
     });
 
-    it('should throw bad request error when there is no layer in mapProxy', async () => {
+    it('should throw not found error when there is no layer in mapProxy', async () => {
       const layerRequest = updateLayerRequest.valid;
       const updatedLayerMetadata = updatedLayer.metadata;
       const updateLayerName = getMapServingLayerName(updatedLayerMetadata.productId, updatedLayerMetadata.productType as ProductType);
@@ -316,7 +316,7 @@ describe('IngestionManager', () => {
         await ingestionManager.updateLayer(updatedLayerMetadata.id, layerRequest);
       };
 
-      await expect(action()).rejects.toThrow(BadRequestError);
+      await expect(action()).rejects.toThrow(NotFoundError);
     });
 
     it('should throw conflict error when there is more then one layer in catalog', async () => {

--- a/tests/unit/ingestion/models/ingestionManager.spec.ts
+++ b/tests/unit/ingestion/models/ingestionManager.spec.ts
@@ -1,6 +1,6 @@
 import jsLogger from '@map-colonies/js-logger';
 import nock from 'nock';
-import { ConflictError, BadRequestError } from '@map-colonies/error-types';
+import { ConflictError, BadRequestError, NotFoundError } from '@map-colonies/error-types';
 import { ProductType } from '@map-colonies/mc-model-types';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import { trace } from '@opentelemetry/api';
@@ -319,7 +319,7 @@ describe('IngestionManager', () => {
       await expect(action()).rejects.toThrow(BadRequestError);
     });
 
-    it('should throw bad request error when there is no layer in catalog', async () => {
+    it('should throw conflict error when there is more then one layer in catalog', async () => {
       const layerRequest = updateLayerRequest.valid;
       const updatedLayerMetadata = updatedLayer.metadata;
 
@@ -337,7 +337,7 @@ describe('IngestionManager', () => {
       await expect(action()).rejects.toThrow(ConflictError);
     });
 
-    it('should throw conflict error when there is more then one layer in catalog', async () => {
+    it('should throw not found error when there is no layer in catalog', async () => {
       const layerRequest = updateLayerRequest.valid;
       const updatedLayerMetadata = updatedLayer.metadata;
 
@@ -352,7 +352,7 @@ describe('IngestionManager', () => {
         await ingestionManager.updateLayer(updatedLayerMetadata.id, layerRequest);
       };
 
-      await expect(action()).rejects.toThrow(BadRequestError);
+      await expect(action()).rejects.toThrow(NotFoundError);
     });
   });
 


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Related issues: #XXX , #XXX ...
Closes #XXX ...

