### PR TITLE
feat: add jobTrackerUrl to additionalParams (MAPCO-5054)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -73,7 +73,8 @@
   "services": {
     "jobManagerURL": "JOB_MANAGER_URL",
     "mapProxyApiServiceUrl": "MAP_PROXY_API_SERVICE_URL",
-    "catalogServiceURL": "CATALOG_SERVICE_URL"
+    "catalogServiceURL": "CATALOG_SERVICE_URL",
+    "jobTrackerServiceURL": "JOB_TRACKER_SERVICE_URL"
   },
   "jobManager": {
     "jobDomain": "JOB_DOMAIN",

--- a/config/default.json
+++ b/config/default.json
@@ -50,7 +50,8 @@
   "services": {
     "jobManagerURL": "",
     "mapProxyApiServiceUrl": "",
-    "catalogServiceURL": ""
+    "catalogServiceURL": "",
+    "jobTrackerServiceURL": ""
   },
   "jobManager": {
     "jobDomain": "RASTER",

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -20,6 +20,7 @@ data:
   JOB_MANAGER_URL: {{ $serviceUrls.jobManager | quote }}
   MAP_PROXY_API_SERVICE_URL: {{ $serviceUrls.mapproxyApi | quote }}
   CATALOG_SERVICE_URL: {{ $serviceUrls.catalogManager | quote }}
+  JOB_TRACKER_SERVICE_URL: {{ $serviceUrls.jobTracker | quote }}
   STORAGE_EXPLORER_DISPLAY_NAME_DIR: {{ .Values.env.storageExplorer.displayNameDir | quote }}
   STORAGE_EXPLORER_LAYER_SOURCE_DIR: {{ .Values.env.storageExplorer.layerSourceDir | quote }}
   STORAGE_EXPLORER_WATCH_DIRECTORY: {{ .Values.env.storageExplorer.watchDirectory | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,10 +4,7 @@ global:
   metrics: {}
   environment: ''
   domain: "RASTER"
-  serviceUrls:
-    mapproxyApi: ""
-    catalogManager: ""
-    jobManager: ""
+  serviceUrls: {}
   jobDefinitions: {}
   storage:
     fs:
@@ -35,6 +32,7 @@ serviceUrls:
   mapproxyApi: ""
   catalogManager: ""
   jobManager: ""
+  jobTracker: ""
 jobDefinitions:
   jobs:
     new:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@map-colonies/error-express-handler": "^2.1.0",
         "@map-colonies/express-access-log-middleware": "^2.0.1",
         "@map-colonies/js-logger": "^1.0.1",
-        "@map-colonies/mc-model-types": "^17.7.1",
+        "@map-colonies/mc-model-types": "^17.7.2",
         "@map-colonies/mc-priority-queue": "^8.1.0",
         "@map-colonies/mc-utils": "^3.1.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
@@ -3377,9 +3377,9 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-17.7.1.tgz",
-      "integrity": "sha512-BJUyHfIDDLLcnKCP0zMYvDNs/HYtJrKAUh84Cbn1oUEvWedB072EqXCfWfzTa0aDijf0DCtAHiB/E2h++2WDYQ==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-17.7.2.tgz",
+      "integrity": "sha512-BGuOEscs0vGAUpy3upZEfs/AlkPJwgEOLSpZ1LG5jysetCPvyee/l6KwS+UfDAFKgtE1GsUpLllhEBq7KpVZAw==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@map-colonies/error-express-handler": "^2.1.0",
     "@map-colonies/express-access-log-middleware": "^2.0.1",
     "@map-colonies/js-logger": "^1.0.1",
-    "@map-colonies/mc-model-types": "^17.7.1",
+    "@map-colonies/mc-model-types": "^17.7.2",
     "@map-colonies/mc-priority-queue": "^8.1.0",
     "@map-colonies/mc-utils": "^3.1.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",

--- a/tests/mocks/configMock.ts
+++ b/tests/mocks/configMock.ts
@@ -85,6 +85,7 @@ const registerDefaultConfig = (): void => {
       jobManagerURL: 'http://jobmanagerurl',
       mapProxyApiServiceUrl: 'http://mapproxyapiserviceurl',
       catalogServiceURL: 'http://catalogserviceurl',
+      jobTrackerServiceURL: 'http://jobTrackerServiceUrl',
     },
     jobManager: {
       jobDomain: 'RASTER',

--- a/tests/mocks/newIngestionRequestMockData.ts
+++ b/tests/mocks/newIngestionRequestMockData.ts
@@ -537,6 +537,9 @@ export const newJobRequest = {
       originDirectory: 'test_files',
       fileNames: ['valid(blueMarble).gpkg'],
     },
+    additionalParams: {
+      jobTrackerServiceURL: 'http://jobTrackerServiceUrl',
+    },
   },
   productName: 'string',
   productType: 'Orthophoto',

--- a/tests/mocks/updateRequestMockData.ts
+++ b/tests/mocks/updateRequestMockData.ts
@@ -202,6 +202,7 @@ export const updateJobRequest = {
     additionalParams: {
       tileOutputFormat: TileOutputFormat.PNG,
       displayPath: 'd698bf1d-bb66-4292-a8b4-524cbeadf36f',
+      jobTrackerServiceURL: 'http://jobTrackerServiceUrl',
     },
   },
   domain: 'RASTER',
@@ -407,6 +408,7 @@ export const updateSwapJobRequest = {
     },
     additionalParams: {
       tileOutputFormat: TileOutputFormat.PNG,
+      jobTrackerServiceURL: 'http://jobTrackerServiceUrl',
     },
   },
   domain: 'RASTER',


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                       |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Added JobTrackerUrl to parameters when creating a new job