### PR TITLE
chore: remove booleanContains turf validation(MAPCO-6803)

### DIFF
--- a/src/ingestion/validators/polygonPartValidator.ts
+++ b/src/ingestion/validators/polygonPartValidator.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { GeoJSON, Geometry, MultiPolygon, Feature } from 'geojson';
+import { Geometry } from 'geojson';
 import { getIssues } from '@placemarkio/check-geojson';
-import booleanContains from '@turf/boolean-contains';
 import isValidGeoJson from '@turf/boolean-valid';
 import { inject, injectable } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
@@ -12,7 +11,7 @@ import { withSpanV4 } from '@map-colonies/telemetry';
 import { LogContext } from '../../utils/logger/logContext';
 import { SERVICES } from '../../common/constants';
 import { InfoDataWithFile } from '../schemas/infoDataSchema';
-import { combineExtentPolygons, extentBuffer, extractPolygons } from '../../utils/geometry';
+import { combineExtentPolygons, extractPolygons } from '../../utils/geometry';
 import { GeometryValidationError, PixelSizeError } from '../errors/ingestionErrors';
 import { isPixelSizeValid } from '../../utils/pixelSizeValidate';
 
@@ -45,14 +44,14 @@ export class PolygonPartValidator {
     this.logger.debug({ msg: 'created combined extent', logContext: logCtx, metadata: { combinedExtent } });
     //run on map and check that the geometry is in extent
     partsData.map((polygonPart, index) => {
-      this.validatePartGeometry(polygonPart, index, combinedExtent);
+      this.validatePartGeometry(polygonPart, index);
       this.validatePartPixelSize(polygonPart, index, infoDataFiles);
     });
     activeSpan?.addEvent('polygonPartValidator.validate.success');
   }
 
   @withSpanV4
-  private validatePartGeometry(polygonPart: PolygonPart, index: number, combinedExtent: Feature<MultiPolygon>): void {
+  private validatePartGeometry(polygonPart: PolygonPart, index: number): void {
     const logCtx = { ...this.logContext, function: this.validatePartGeometry.name };
     const activeSpan = trace.getActiveSpan();
     activeSpan?.updateName('polygonPartValidator.validatePartGeometry');

--- a/src/ingestion/validators/polygonPartValidator.ts
+++ b/src/ingestion/validators/polygonPartValidator.ts
@@ -71,20 +71,6 @@ export class PolygonPartValidator {
       });
       throw new GeometryValidationError(polygonPart.sourceName, index, 'Geometry is invalid');
     }
-    const containedByExtent = this.isContainedByExtent(polygonPart.footprint as Geometry, combinedExtent as GeoJSON);
-    this.logger.debug({
-      msg: `validated geometry of part ${polygonPart.sourceName} at index: ${index}. containedByExtent: ${containedByExtent}`,
-      logContext: logCtx,
-      metadata: { polygonPart },
-    });
-    if (!containedByExtent) {
-      this.logger.error({
-        msg: `Geometry of ${polygonPart.sourceName} at index: ${index} is not contained by combined extent`,
-        logContext: logCtx,
-        metadata: { polygonPart, combinedExtent },
-      });
-      throw new GeometryValidationError(polygonPart.sourceName, index, 'Geometry is not contained by combined extent');
-    }
   }
 
   @withSpanV4
@@ -98,23 +84,6 @@ export class PolygonPartValidator {
     }
     activeSpan?.addEvent('polygonPartValidator.validateGeometry.failed');
     return false;
-  }
-
-  @withSpanV4
-  private isContainedByExtent(footprint: Geometry, extent: GeoJSON): boolean {
-    const activeSpan = trace.getActiveSpan();
-    activeSpan?.updateName('polygonPartValidator.isContainedByExtent');
-    const bufferedExtent = extentBuffer(this.extentBufferInMeters, extent);
-    if (!(booleanContains(bufferedExtent as unknown as Geometry, footprint) || booleanContains(extent as Geometry, footprint))) {
-      activeSpan?.addEvent('polygonPartValidator.isContainedByExtent.false', {
-        providedExtent: JSON.stringify(extent),
-        bufferedExtent: JSON.stringify(bufferedExtent),
-        footprint: JSON.stringify(footprint),
-      });
-      return false;
-    }
-    activeSpan?.addEvent('polygonPartValidator.isContainedByExtent.true');
-    return true;
   }
 
   @withSpanV4

--- a/tests/integration/ingestion/ingestion.spec.ts
+++ b/tests/integration/ingestion/ingestion.spec.ts
@@ -451,14 +451,6 @@ describe('Ingestion', function () {
         expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
       });
 
-      it('should return 400 status code when partsData polygon geometry isnt contained by extent', async () => {
-        const layerRequest = newLayerRequest.invalid.notContainedPolygon;
-        const response = await requestSender.ingestNewLayer(layerRequest);
-
-        expect(response).toSatisfyApiSpec();
-        expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
-      });
-
       it('should return 400 status code when partsData resolutionDeg isnt greater than pixel size', async () => {
         const layerRequest = newLayerRequest.invalid.invalidResolutionDeg;
         const response = await requestSender.ingestNewLayer(layerRequest);
@@ -652,7 +644,7 @@ describe('Ingestion', function () {
       });
 
       it('should return 400 status code when there is a validation error', async () => {
-        const layerRequest = updateLayerRequest.invalid.notContainedPolygon;
+        const layerRequest = updateLayerRequest.invalid.metadata;
         const updatedLayerMetadata = updatedLayer.metadata;
 
         const response = await requestSender.updateLayer(updatedLayerMetadata.id, layerRequest);

--- a/tests/unit/ingestion/validators/polygonPartValidator.spec.ts
+++ b/tests/unit/ingestion/validators/polygonPartValidator.spec.ts
@@ -28,11 +28,6 @@ describe('PolygonPartValidator', () => {
       expect(result).toThrow(GeometryValidationError);
     });
 
-    it('should throw geometry validation error on partsData geometry not contained by extent', () => {
-      const result = () => polygonPartValidator.validate(polygonPartsMock.invalid.notContainedGeometry, infoDataMock);
-      expect(result).toThrow(GeometryValidationError);
-    });
-
     it('should throw pixelSize validation error on partsData when resolutionDeg isnt greater than pixelSize from infoData', () => {
       const result = () => polygonPartValidator.validate(polygonPartsMock.invalid.notValidResolutionDeg, infoDataMock);
       expect(result).toThrow(PixelSizeError);


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                       |
| Chore            | ✔                                                                       |

# Remove `booleanContains` Validation

## Description
Temporarily removing the `booleanContains` validation as it is currently ineffective and inefficient.