### PR TITLE
fix: removing max_old_space_size from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --chown=node:node ./config ./config
 
 USER node
 EXPOSE 8080
-CMD ["dumb-init", "node", "--max_old_space_size=512", "--require", "./common/tracing.js", "./index.js"]
+CMD ["dumb-init", "node",  "--require", "./common/tracing.js", "./index.js"]


### PR DESCRIPTION

| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖      |
| New feature     | ✖      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✖      |
| Chore           | ✔      |

