### PR TITLE
fix: bypass attempt with isValid as true does not indicate for an error (MAPCO-10606)

### DIFF
--- a/src/ingestion/models/ingestionManager.ts
+++ b/src/ingestion/models/ingestionManager.ts
@@ -1,6 +1,6 @@
 import { relative } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { BadRequestError, ConflictError, NotFoundError } from '@map-colonies/error-types';
+import { ConflictError, NotFoundError } from '@map-colonies/error-types';
 import { Logger } from '@map-colonies/js-logger';
 import {
   IFindJobsByCriteriaBody,
@@ -234,37 +234,7 @@ export class IngestionManager {
     const job: IJobResponse<IngestionBaseJobParams, unknown> = await this.jobManagerWrapper.getJob<IngestionBaseJobParams, unknown>(jobId);
     const validationTask = await this.getValidationTask(jobId, { ...logCtx });
 
-    if (validationTask.parameters.isValid === true) {
-      return;
-    }
-    if (job.status !== OperationStatus.SUSPENDED) {
-      throw new BadRequestError('cannot bypass validation errors when the job is not suspended');
-    }
-    if (validationTask.parameters.errorsSummary === undefined) {
-      throw new UnsupportedEntityError('cannot bypass validation errors when there are no validation errors in task params');
-    }
-
-    const errorsSummary = validationTask.parameters.errorsSummary;
-    const exceededResolutionThreshold = errorsSummary.thresholds.resolution.exceeded;
-
-    for (const [errorType, errorCount] of Object.entries(errorsSummary.errorsCount)) {
-      if (errorCount > 0 && !allowedValidationErrors.includes(errorType)) {
-        throw new UnsupportedEntityError('validation task has additional errors that are not in the allowed list');
-      }
-    }
-    if (exceededResolutionThreshold) {
-      throw new UnsupportedEntityError('cannot bypass validation error of type: resolution, because the resolution exceeded threshold');
-    }
-
-    const existingChecksums = validationTask.parameters.checksums;
-    const metadataShapefilePath = await this.validateAndGetAbsoluteInputFiles(job.parameters.inputFiles);
-    const newChecksums = await this.getChecksum(metadataShapefilePath.metadataShapefilePath);
-    if (this.isChecksumChanged(existingChecksums, newChecksums)) {
-      throw new ConflictError(
-        'cannot bypass validation errors because the metadata shapefile has been changed since the validation was performed,re-run the process'
-      );
-    }
-
+    await this.canBypassValidationTask({ ...body, ingestionValidationTaskParams: validationTask.parameters, job });
     await this.makeValidationTaskCompleted(validationTask);
     await this.jobManagerWrapper.updateJob(jobId, {
       status: OperationStatus.IN_PROGRESS,
@@ -781,6 +751,47 @@ export class IngestionManager {
       ...checksum,
       fileName: relative(this.sourceMount, checksum.fileName),
     }));
+  }
+
+  private async canBypassValidationTask(
+    options: {
+      ingestionValidationTaskParams: IngestionValidationTaskParams;
+      job: IJobResponse<IngestionBaseJobParams, unknown>;
+    } & IBypassValidationErrorsRequestBody
+  ): Promise<void> {
+    const { allowedValidationErrors, ingestionValidationTaskParams, job } = options;
+
+    if (ingestionValidationTaskParams.isValid === true) {
+      throw new UnsupportedEntityError('cannot bypass validation errors since the validation was already successfully completed');
+    }
+    if (job.status !== OperationStatus.SUSPENDED) {
+      throw new UnsupportedEntityError('cannot bypass validation errors when the job is not suspended');
+    }
+    if (ingestionValidationTaskParams.errorsSummary === undefined) {
+      throw new UnsupportedEntityError('cannot bypass validation errors when there are no validation errors in task params');
+    }
+
+    const errorsSummary = ingestionValidationTaskParams.errorsSummary;
+    const exceededResolutionThreshold = errorsSummary.thresholds.resolution.exceeded;
+
+    if (exceededResolutionThreshold) {
+      throw new UnsupportedEntityError('cannot bypass validation error of type: resolution, because the resolution exceeded threshold');
+    }
+
+    for (const [errorType, errorCount] of Object.entries(errorsSummary.errorsCount)) {
+      if (errorCount > 0 && !allowedValidationErrors.includes(errorType)) {
+        throw new UnsupportedEntityError('validation task has additional errors that are not in the allowed list');
+      }
+    }
+
+    const existingChecksums = ingestionValidationTaskParams.checksums;
+    const metadataShapefilePath = await this.validateAndGetAbsoluteInputFiles(job.parameters.inputFiles);
+    const newChecksums = await this.getChecksum(metadataShapefilePath.metadataShapefilePath);
+    if (this.isChecksumChanged(existingChecksums, newChecksums)) {
+      throw new ConflictError(
+        'cannot bypass validation errors because the metadata shapefile has been changed since the validation was performed, re-run the process'
+      );
+    }
   }
 
   private async makeValidationTaskCompleted(task: ITaskResponse<IngestionValidationTaskParams>): Promise<void> {

--- a/tests/integration/ingestion/ingestion.spec.ts
+++ b/tests/integration/ingestion/ingestion.spec.ts
@@ -2260,37 +2260,6 @@ describe('Ingestion', () => {
         nock(configMock.get<string>('services.jobTrackerServiceURL')).post(`/tasks/${taskId}/notify`).reply(httpStatusCodes.OK);
 
         const response = await requestSender.bypassValidationErrors(jobId, requestBody);
-        console.log('BYPASS RES:', response.body);
-
-        expect(response).toSatisfyApiSpec();
-        expect(response.status).toBe(httpStatusCodes.OK);
-      });
-
-      it('should return 200 when task is valid', async () => {
-        const jobId = faker.string.uuid();
-        const taskId = faker.string.uuid();
-        const bypassJob = createBypassJob({ jobId });
-        const requestBody = { allowedValidationErrors: ['resolution'], approver: 'approverName' };
-
-        const validationTask = {
-          id: taskId,
-          jobId,
-          type: configMock.get<string>('jobManager.validationTaskType'),
-          status: OperationStatus.SUSPENDED,
-          parameters: {
-            isValid: true,
-            checksums: validInputFiles.checksums,
-            errorsSummary: {
-              errorsCount: { resolution: 1 },
-              thresholds: { resolution: { exceeded: false } },
-            },
-          },
-        };
-
-        nock(jobManagerURL).get(`/jobs/${jobId}`).query({ shouldReturnTasks: false }).reply(httpStatusCodes.OK, bypassJob);
-        nock(jobManagerURL).get(`/jobs/${jobId}/tasks`).reply(httpStatusCodes.OK, [validationTask]);
-
-        const response = await requestSender.bypassValidationErrors(jobId, requestBody);
 
         expect(response).toSatisfyApiSpec();
         expect(response.status).toBe(httpStatusCodes.OK);
@@ -2298,10 +2267,10 @@ describe('Ingestion', () => {
     });
 
     describe('Bad Path', () => {
-      it('should return 400 BAD_REQUEST when job is not suspended', async () => {
+      it('should return 422 UNPROCESSABLE_ENTITY when job is not suspended', async () => {
         const jobId = faker.string.uuid();
         const taskId = faker.string.uuid();
-        const bypassJob = createBypassJob({ jobId, status: OperationStatus.PENDING });
+        const bypassJob = createBypassJob({ jobId, status: OperationStatus.FAILED });
         const requestBody = { allowedValidationErrors: ['resolution'], approver: 'approverName' };
 
         const validationTask = {
@@ -2325,7 +2294,36 @@ describe('Ingestion', () => {
         const response = await requestSender.bypassValidationErrors(jobId, requestBody);
 
         expect(response).toSatisfyApiSpec();
-        expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+        expect(response.status).toBe(httpStatusCodes.UNPROCESSABLE_ENTITY);
+      });
+
+      it('should return 422 UNPROCESSABLE_ENTITY when validation task was already successfully accomplished', async () => {
+        const jobId = faker.string.uuid();
+        const taskId = faker.string.uuid();
+        const bypassJob = createBypassJob({ jobId, status: OperationStatus.COMPLETED });
+        const requestBody = { allowedValidationErrors: ['resolution'], approver: 'approverName' };
+        const validationTask = {
+          id: taskId,
+          jobId,
+          type: configMock.get<string>('jobManager.validationTaskType'),
+          status: OperationStatus.COMPLETED,
+          parameters: {
+            isValid: true,
+            checksums: validInputFiles.checksums,
+            errorsSummary: {
+              errorsCount: { resolution: 0, geometryValidity: 0, metadata: 0, smallGeometries: 0, smallHoles: 0, unknown: 0, vertices: 0 },
+              thresholds: { resolution: { exceeded: false }, smallGeometries: { exceeded: false }, smallHoles: { count: 0, exceeded: false } },
+            },
+          },
+        };
+
+        nock(jobManagerURL).get(`/jobs/${jobId}`).query({ shouldReturnTasks: false }).reply(httpStatusCodes.OK, bypassJob);
+        nock(jobManagerURL).get(`/jobs/${jobId}/tasks`).reply(httpStatusCodes.OK, [validationTask]);
+
+        const response = await requestSender.bypassValidationErrors(jobId, requestBody);
+
+        expect(response).toSatisfyApiSpec();
+        expect(response.status).toBe(httpStatusCodes.UNPROCESSABLE_ENTITY);
       });
 
       it('should return 422 UNPROCESSABLE_ENTITY when there are no validation errors in task params', async () => {

--- a/tests/unit/ingestion/models/ingestionManager.spec.ts
+++ b/tests/unit/ingestion/models/ingestionManager.spec.ts
@@ -1209,7 +1209,7 @@ describe('IngestionManager', () => {
       expect(mockJobTrackerClient.notify).toHaveBeenCalledWith(mockTask);
     });
 
-    it('should return and do nothing when task is valid', async () => {
+    it('should throw UnsupportedEntityError when task is valid', async () => {
       const mockJobId = faker.string.uuid();
       const mockJob = generateMockJob({ status: OperationStatus.SUSPENDED });
       const mockTask = {
@@ -1235,8 +1235,9 @@ describe('IngestionManager', () => {
       getJobSpy.mockResolvedValue(mockJob);
       getTasksForJobSpy.mockResolvedValue([mockTask]);
 
-      await ingestionManager.bypassValidationErrors(body, mockJobId);
+      const response = ingestionManager.bypassValidationErrors(body, mockJobId);
       expect(mockJobTrackerClient.notify).not.toHaveBeenCalled();
+      await expect(response).rejects.toThrow(UnsupportedEntityError);
     });
 
     it('should throw BadRequestError if job is not suspended', async () => {
@@ -1265,7 +1266,8 @@ describe('IngestionManager', () => {
       getJobSpy.mockResolvedValue(mockJob);
       getTasksForJobSpy.mockResolvedValue([mockTask]);
 
-      await expect(ingestionManager.bypassValidationErrors(body, mockJobId)).rejects.toThrow(BadRequestError);
+      const response = ingestionManager.bypassValidationErrors(body, mockJobId);
+      await expect(response).rejects.toThrow(UnsupportedEntityError);
     });
 
     it('should throw UnsupportedEntityError if task has unallowed errors', async () => {

--- a/tests/unit/ingestion/models/ingestionManager.spec.ts
+++ b/tests/unit/ingestion/models/ingestionManager.spec.ts
@@ -1240,7 +1240,7 @@ describe('IngestionManager', () => {
       await expect(response).rejects.toThrow(UnsupportedEntityError);
     });
 
-    it('should throw BadRequestError if job is not suspended', async () => {
+    it('should throw UnsupportedEntityError if job is not suspended', async () => {
       const mockJobId = faker.string.uuid();
       const mockJob = generateMockJob({ status: OperationStatus.PENDING });
       const mockTask = {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

throw UnsupportedEntityError on invalid task or suspended job